### PR TITLE
Card style update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
+    implementation(libs.androidx.foundation)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     debugImplementation(platform(libs.androidx.compose.bom))
 

--- a/app/src/main/java/ie/setu/project/views/clothing/ClothingScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/clothing/ClothingScreen.kt
@@ -1,6 +1,7 @@
 package ie.setu.project.views.clothing
 
 import android.net.Uri
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
@@ -25,6 +26,13 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import ie.setu.project.R
 import ie.setu.project.models.clothing.ClosetOrganiserModel
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.Checkroom
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -136,27 +144,82 @@ fun ClothingScreen(
 
 @Composable
 private fun ClothingRow(item: ClosetOrganiserModel, onClick: () -> Unit, onDelete: () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick), elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)) {
-        Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        border = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             val imageModel: Any? = item.imageUrl.takeIf { it.isNotBlank() } ?: item.image
             val ok = imageModel != null && imageModel != Uri.EMPTY && imageModel.toString().isNotBlank()
-            if (ok) {
-                AsyncImage(model = imageModel, contentDescription = "Clothing image", modifier = Modifier.size(64.dp))
-            } else {
-                Box(modifier = Modifier.size(64.dp), contentAlignment = Alignment.Center) {
-                    Text("No image", color = Color.Gray)
+
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color(0xFFF5F5F5))
+                    .border(2.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                if (ok) {
+                    AsyncImage(
+                        model = imageModel,
+                        contentDescription = "Clothing image",
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(6.dp),
+                        contentScale = ContentScale.Fit
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.Checkroom,
+                        contentDescription = "No image",
+                        tint = Color.LightGray,
+                        modifier = Modifier.size(32.dp)
+                    )
                 }
             }
+
             Spacer(Modifier.width(12.dp))
+
             Column(modifier = Modifier.weight(1f)) {
                 Text(item.title.ifBlank { "No title" }, fontWeight = FontWeight.Bold)
                 Spacer(Modifier.height(2.dp))
                 Text(item.description.ifBlank { "No description" }, style = MaterialTheme.typography.bodySmall)
                 Spacer(Modifier.height(4.dp))
-                Text("Category: ${item.category.ifBlank { "None" }}", style = MaterialTheme.typography.labelSmall, color = Color.Gray)
+                Text(
+                    "Category: ${item.category.ifBlank { "None" }}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.Gray
+                )
             }
-            IconButton(onClick = onDelete) {
-                Icon(Icons.Default.Delete, "Delete", tint = Color.Red)
+
+            Box {
+                IconButton(onClick = { menuExpanded = true }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                }
+                DropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Delete", color = Color.Red) },
+                        leadingIcon = {
+                            Icon(Icons.Default.Delete, contentDescription = null, tint = Color.Red)
+                        },
+                        onClick = {
+                            menuExpanded = false
+                            onDelete()
+                        }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/ie/setu/project/views/clothingList/ClothingListScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/clothingList/ClothingListScreen.kt
@@ -5,7 +5,9 @@ import android.net.Uri
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
@@ -381,11 +383,29 @@ fun SearchResultItem(item: Any, onClothingClick: (ClosetOrganiserModel) -> Unit,
     val subtitle = when (item) { is ClosetOrganiserModel -> item.description.ifBlank { "No description" }; is OutfitModel -> item.description.ifBlank { "No description" }; else -> "" }
     val icon = when (item) { is OutfitModel -> Icons.Default.Style; else -> Icons.Default.Checkroom }
 
-    Card(modifier = Modifier.fillMaxWidth().clickable { when (item) { is ClosetOrganiserModel -> onClothingClick(item); is OutfitModel -> onOutfitClick(item) } }, shape = RoundedCornerShape(12.dp)) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable { when (item) { is ClosetOrganiserModel -> onClothingClick(item); is OutfitModel -> onOutfitClick(item) } },
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        border = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
+    ) {
         Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
-            Box(modifier = Modifier.size(52.dp).clip(RoundedCornerShape(10.dp)).background(Color.LightGray), contentAlignment = Alignment.Center) {
-                if (isValidThumb) AsyncImage(model = thumbModel, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
-                else Icon(imageVector = icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(26.dp))
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color(0xFFF5F5F5))
+                    .border(2.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isValidThumb) AsyncImage(
+                    model = thumbModel,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().padding(4.dp),
+                    contentScale = ContentScale.Fit
+                )
+                else Icon(imageVector = icon, contentDescription = null, tint = Color.LightGray, modifier = Modifier.size(26.dp))
             }
             Spacer(Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
@@ -393,13 +413,29 @@ fun SearchResultItem(item: Any, onClothingClick: (ClosetOrganiserModel) -> Unit,
                 Text(subtitle, fontSize = 12.sp, maxLines = 2)
             }
             if (item is OutfitModel) {
-                Row(modifier = Modifier.padding(start = 8.dp).height(42.dp).widthIn(max = 150.dp).horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier.padding(start = 8.dp).height(42.dp).widthIn(max = 150.dp).horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     item.clothingItems.take(4).forEach { clothing ->
                         val miniModel: Any? = clothing.imageUrl.takeIf { it.isNotBlank() } ?: clothing.image
                         val ok = miniModel != null && miniModel != Uri.EMPTY && miniModel.toString().isNotBlank()
-                        Box(modifier = Modifier.size(42.dp).clip(RoundedCornerShape(10.dp)).background(Color.LightGray), contentAlignment = Alignment.Center) {
-                            if (ok) AsyncImage(model = miniModel, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
-                            else Icon(imageVector = Icons.Default.Checkroom, contentDescription = null, tint = Color.White, modifier = Modifier.size(18.dp))
+                        Box(
+                            modifier = Modifier
+                                .size(42.dp)
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(Color(0xFFF5F5F5))
+                                .border(1.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (ok) AsyncImage(
+                                model = miniModel,
+                                contentDescription = null,
+                                modifier = Modifier.fillMaxSize().padding(4.dp),
+                                contentScale = ContentScale.Fit
+                            )
+                            else Icon(imageVector = Icons.Default.Checkroom, contentDescription = null, tint = Color.LightGray, modifier = Modifier.size(18.dp))
                         }
                     }
                 }

--- a/app/src/main/java/ie/setu/project/views/donation/DonationScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationScreen.kt
@@ -1,7 +1,9 @@
 package ie.setu.project.views.donation
 
 import android.net.Uri
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -199,20 +201,31 @@ private fun DonationItemCard(
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(14.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        colors    = CardDefaults.cardColors(containerColor = Color.Transparent),
+        border    = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
     ) {
         Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
 
             Box(
-                modifier = Modifier.size(72.dp).clip(RoundedCornerShape(10.dp)).background(Color.LightGray),
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color(0xFFF5F5F5))
+                    .border(2.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 val imageModel: Any? = item.imageUrl.takeIf { it.isNotBlank() } ?: item.image
                 val hasImage = imageModel != null && imageModel != Uri.EMPTY && imageModel.toString().isNotBlank()
                 if (hasImage) {
-                    AsyncImage(model = imageModel, contentDescription = item.title, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                    AsyncImage(
+                        model = imageModel,
+                        contentDescription = item.title,
+                        modifier = Modifier.fillMaxSize().padding(6.dp),
+                        contentScale = ContentScale.Fit
+                    )
                 } else {
-                    Icon(Icons.Default.Checkroom, contentDescription = null, tint = Color.White, modifier = Modifier.size(32.dp))
+                    Icon(Icons.Default.Checkroom, contentDescription = null, tint = Color.LightGray, modifier = Modifier.size(32.dp))
                 }
             }
 

--- a/app/src/main/java/ie/setu/project/views/outfits/OutfitScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/outfits/OutfitScreen.kt
@@ -1,19 +1,27 @@
-package ie.setu.project.views.outfit
+package ie.setu.project.views.outfits
 
 import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Checkroom
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -81,20 +89,92 @@ fun OutfitScreen(
 
 @Composable
 private fun OutfitRow(outfit: OutfitModel, onClick: () -> Unit, onDelete: () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth(), elevation = CardDefaults.cardElevation(defaultElevation = 6.dp), onClick = onClick) {
-        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Text(text = outfit.title.ifBlank { "No title" }, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
-                IconButton(onClick = onDelete) {
-                    Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete outfit", tint = Color.Red)
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        border = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = outfit.title.ifBlank { "No title" },
+                        fontWeight = FontWeight.Bold
+                    )
+                    if (outfit.description.isNotBlank()) {
+                        Text(
+                            text = outfit.description,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray
+                        )
+                    }
+                }
+                Box {
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                    }
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Delete", color = Color.Red) },
+                            leadingIcon = {
+                                Icon(Icons.Default.Delete, contentDescription = null, tint = Color.Red)
+                            },
+                            onClick = {
+                                menuExpanded = false
+                                onDelete()
+                            }
+                        )
+                    }
                 }
             }
-            Row(modifier = Modifier.fillMaxWidth().height(90.dp).horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 outfit.clothingItems.forEach { clothing ->
                     val imageModel: Any? = clothing.imageUrl.takeIf { it.isNotBlank() } ?: clothing.image
                     val ok = imageModel != null && imageModel != Uri.EMPTY && imageModel.toString().isNotBlank()
-                    if (ok) {
-                        AsyncImage(model = imageModel, contentDescription = "Clothing image", modifier = Modifier.height(90.dp).width(90.dp), contentScale = ContentScale.Crop)
+                    Box(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(Color(0xFFF5F5F5))
+                            .border(2.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (ok) {
+                            AsyncImage(
+                                model = imageModel,
+                                contentDescription = "Clothing image",
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(6.dp),
+                                contentScale = ContentScale.Fit
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Checkroom,
+                                contentDescription = "No image",
+                                tint = Color.LightGray,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/ie/setu/project/views/outfits/OutfitScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/outfits/OutfitScreen.kt
@@ -1,4 +1,4 @@
-package ie.setu.project.views.outfits
+package ie.setu.project.views.outfit
 
 import android.net.Uri
 import androidx.compose.foundation.BorderStroke

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ playServicesAuth = "21.3.0"
 googleid = "1.1.0"
 ui = "1.10.5"
 datastorePreferences = "1.1.1"
+foundation = "1.10.6"
 
 
 
@@ -145,6 +146,7 @@ googleid = { group = "com.google.android.libraries.identity.googleid", name = "g
 androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
+androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Replaces the old elevated solid cards with a clean transparent + teal border style throughout the app.

- Clothing, outfit, donation and search result cards now use transparent 
  background with a soft teal border matching the top app bar colour
- Clothing thumbnails updated to grey background with matching teal border, 
  ContentScale.Fit and padding so full garments are always visible
- Replaced direct delete buttons with a 3-dot dropdown menu on clothing 
  and outfit cards
- Applied consistently across ClothingScreen, OutfitScreen, DonationScreen 
  and the search results in ClothingListScreen