### PR TITLE
Settings page

### DIFF
--- a/app/src/main/java/ie/setu/project/ui/user/UserProfileScreen.kt
+++ b/app/src/main/java/ie/setu/project/ui/user/UserProfileScreen.kt
@@ -26,9 +26,8 @@ import coil.compose.AsyncImage
 @Composable
 fun UserProfileScreen(
     onBack: () -> Unit,
-    onExportWardrobe: () -> Unit,
-    onSignOut: () -> Unit,
     onEditProfile: () -> Unit,
+    onNavigateToSettings: () -> Unit,
     vm: ProfileViewModel = hiltViewModel()
 ) {
     val profile by vm.profile.collectAsState()
@@ -39,18 +38,22 @@ fun UserProfileScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Text("My Profile", fontSize = 26.sp, fontFamily = FontFamily.Cursive, color = Color.White)
                     }
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
                     }
                 },
                 actions = {
-                    IconButton(onClick = onEditProfile) {
-                        Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit Profile", tint = Color.White)
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings", tint = Color.White)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -61,27 +64,43 @@ fun UserProfileScreen(
         }
     ) { padding ->
         Column(
-            modifier = Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(24.dp),
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             Spacer(Modifier.height(16.dp))
 
             Box(
-                modifier = Modifier.size(100.dp).clip(CircleShape)
+                modifier = Modifier
+                    .size(100.dp)
+                    .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)),
                 contentAlignment = Alignment.Center
             ) {
                 val photoModel: Any? = profile.photoUrl.takeIf { it.isNotBlank() }
                 if (photoModel != null) {
-                    AsyncImage(model = photoModel, contentDescription = "Profile photo", modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                    AsyncImage(
+                        model = photoModel,
+                        contentDescription = "Profile photo",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
                 } else {
-                    Icon(imageVector = Icons.Default.Person, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(56.dp))
+                    Icon(
+                        imageVector = Icons.Default.Person,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(56.dp)
+                    )
                 }
             }
 
             val displayName = profile.displayName.takeIf { it.isNotBlank() } ?: "User"
-            Text(text = displayName, fontSize = 24.sp, fontWeight = FontWeight.Bold, color = Color(0xFF1A1A1A))
+            Text(displayName, fontSize = 24.sp, fontWeight = FontWeight.Bold, color = Color(0xFF1A1A1A))
 
             ProfileInfoCard(
                 icon = { Icon(Icons.Default.Email, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(22.dp)) },
@@ -95,44 +114,19 @@ fun UserProfileScreen(
                     label = "Bio",
                     value = profile.bio
                 )
-            } else {
-                OutlinedButton(onClick = onEditProfile, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(12.dp)) {
-                    Icon(Icons.Default.Edit, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
-                    Spacer(Modifier.width(8.dp))
-                    Text("Add a bio", color = MaterialTheme.colorScheme.primary)
-                }
             }
 
             Spacer(Modifier.height(8.dp))
 
             Button(
-                onClick = onEditProfile, modifier = Modifier.fillMaxWidth().height(52.dp),
+                onClick = onEditProfile,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
                 shape = RoundedCornerShape(12.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
                 Icon(Icons.Default.Edit, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
                 Spacer(Modifier.width(10.dp))
                 Text("Edit Profile", fontSize = 16.sp, color = Color.White)
-            }
-
-            Button(
-                onClick = onExportWardrobe, modifier = Modifier.fillMaxWidth().height(52.dp),
-                shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
-            ) {
-                Icon(Icons.Default.FileDownload, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
-                Spacer(Modifier.width(10.dp))
-                Text("Export Wardrobe", fontSize = 16.sp, color = Color.White)
-            }
-
-            Button(
-                onClick = onSignOut, modifier = Modifier.fillMaxWidth().height(52.dp),
-                shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFD32F2F))
-            ) {
-                Icon(Icons.Default.Logout, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
-                Spacer(Modifier.width(10.dp))
-                Text("Sign Out", fontSize = 16.sp, color = Color.White)
             }
         }
     }

--- a/app/src/main/java/ie/setu/project/views/clothingList/ClothingListScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/clothingList/ClothingListScreen.kt
@@ -2,9 +2,6 @@ package ie.setu.project.views.clothingList
 
 import android.content.Context
 import android.net.Uri
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -38,47 +35,9 @@ import ie.setu.project.models.clothing.ClosetOrganiserModel
 import ie.setu.project.models.outfit.OutfitModel
 import ie.setu.project.models.weather.WeatherCondition
 import ie.setu.project.models.weather.WeatherResponse
-import kotlinx.coroutines.delay
 import ie.setu.project.views.ai.AiStylistScreen
 
 
-@Composable
-fun OfflineSyncBanner(syncState: SyncState) {
-    var showSyncedConfirm by remember { mutableStateOf(false) }
-    LaunchedEffect(syncState) {
-        if (syncState == SyncState.SYNCED) {
-            showSyncedConfirm = true
-            delay(3_000)
-            showSyncedConfirm = false
-        }
-    }
-
-    val (bgColor, icon, message) = when (syncState) {
-        SyncState.SYNCING        -> Triple(Color(0xFF1565C0), Icons.Default.Sync,      "Syncing with cloud…")
-        SyncState.SYNCED         -> Triple(Color(0xFF2E7D32), Icons.Default.CloudDone, "Up to date")
-        SyncState.OFFLINE_CACHE  -> Triple(Color(0xFFE65100), Icons.Default.CloudOff,  "Offline — changes will sync when you're back online")
-        SyncState.OFFLINE_BACKUP -> Triple(Color(0xFFC62828), Icons.Default.CloudOff,  "Offline — showing local backup (read-only)")
-    }
-
-    val visible = syncState == SyncState.SYNCING ||
-            syncState == SyncState.OFFLINE_CACHE ||
-            syncState == SyncState.OFFLINE_BACKUP ||
-            showSyncedConfirm
-
-    AnimatedVisibility(visible = visible, enter = fadeIn(), exit = fadeOut()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(bgColor)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(imageVector = icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(18.dp))
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(text = message, color = Color.White, fontSize = 13.sp)
-        }
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -243,7 +202,6 @@ fun ClothingListScreen(
 
         Column(modifier = Modifier.fillMaxSize().padding(paddingValues).verticalScroll(rememberScrollState())) {
 
-            OfflineSyncBanner(syncState = syncState)
 
             Row(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),

--- a/app/src/main/java/ie/setu/project/views/clothingList/ClothingListView.kt
+++ b/app/src/main/java/ie/setu/project/views/clothingList/ClothingListView.kt
@@ -26,14 +26,14 @@ import ie.setu.project.ui.user.UserProfileScreen
 import ie.setu.project.views.calendar.CalendarView
 import ie.setu.project.views.clothing.ClothingView
 import ie.setu.project.views.donation.DonationView
+import ie.setu.project.views.donation.DonationViewModel
 import ie.setu.project.views.outfit.OutfitView
+import ie.setu.project.views.settings.SettingsScreen
+import ie.setu.project.views.tryOn.TryOnView
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import ie.setu.project.views.tryOn.TryOnView
-import ie.setu.project.views.donation.DonationViewModel
-
 
 @AndroidEntryPoint
 class ClothingListView : AppCompatActivity(), ClosetItemListener {
@@ -51,11 +51,10 @@ class ClothingListView : AppCompatActivity(), ClosetItemListener {
             val syncState by presenter.syncState.collectAsStateWithLifecycle()
             val exportJson by presenter.exportJson.collectAsStateWithLifecycle()
 
-
-
             var showRegister by remember { mutableStateOf(false) }
             var showProfile by remember { mutableStateOf(false) }
             var showEditProfile by remember { mutableStateOf(false) }
+            var showSettings by remember { mutableStateOf(false) }
 
             LaunchedEffect(exportJson) {
                 exportJson?.let { json ->
@@ -80,6 +79,7 @@ class ClothingListView : AppCompatActivity(), ClosetItemListener {
                     showRegister = false
                     showProfile = false
                     showEditProfile = false
+                    showSettings = false
                 }
             }
 
@@ -102,12 +102,21 @@ class ClothingListView : AppCompatActivity(), ClosetItemListener {
                 return@ClosetOrganiserTheme
             }
 
+            if (showSettings) {
+                SettingsScreen(
+                    syncState = syncState,
+                    onExportWardrobe = { presenter.exportWardrobe(); showSettings = false },
+                    onSignOut = { authVm.signOut(); showSettings = false },
+                    onBack = { showSettings = false }
+                )
+                return@ClosetOrganiserTheme
+            }
+
             if (showProfile) {
                 UserProfileScreen(
                     onBack = { showProfile = false },
-                    onExportWardrobe = { presenter.exportWardrobe(); showProfile = false },
-                    onSignOut = { authVm.signOut() },
-                    onEditProfile = { showEditProfile = true }
+                    onEditProfile = { showEditProfile = true },
+                    onNavigateToSettings = { showSettings = true }
                 )
                 return@ClosetOrganiserTheme
             }
@@ -119,7 +128,7 @@ class ClothingListView : AppCompatActivity(), ClosetItemListener {
                 onExportWardrobe = { presenter.exportWardrobe() },
                 onNavigateToClothing = { startActivity(Intent(this, ClothingView::class.java)) },
                 onNavigateToOutfit = { startActivity(Intent(this, OutfitView::class.java)) },
-                onNavigateToCalendar = { startActivity(Intent(this, CalendarView::class.java)) }, // ADD
+                onNavigateToCalendar = { startActivity(Intent(this, CalendarView::class.java)) },
                 onClothingItemClick = { item ->
                     startActivity(Intent(this, ClothingView::class.java).apply {
                         putExtra("closet_item_edit", item)

--- a/app/src/main/java/ie/setu/project/views/settings/SettingsScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/settings/SettingsScreen.kt
@@ -1,0 +1,274 @@
+package ie.setu.project.views.settings
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ie.setu.project.R
+import ie.setu.project.views.clothingList.SyncState
+import kotlinx.coroutines.delay
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    syncState: SyncState,
+    onExportWardrobe: () -> Unit,
+    onSignOut: () -> Unit,
+    onBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, "Back", tint = Color.White)
+                    }
+                },
+                title = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(painterResource(R.drawable.ic_heart), null, tint = Color.White)
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            "Settings",
+                            fontSize = 30.sp,
+                            fontFamily = FontFamily.Cursive,
+                            color = Color.White
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Icon(painterResource(R.drawable.ic_heart), null, tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+
+
+            SyncStatusCard(syncState = syncState)
+
+            Text(
+                "Data & Backup",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 4.dp, top = 4.dp)
+            )
+            Card(
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                SettingsRow(
+                    icon = Icons.Default.CloudUpload,
+                    title = "Export Wardrobe",
+                    subtitle = "Download a backup of all your clothing and outfits",
+                    onClick = onExportWardrobe
+                )
+            }
+
+            Text(
+                "Account",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 4.dp, top = 4.dp)
+            )
+
+            Button(
+                onClick = onSignOut,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFD32F2F))
+            ) {
+                Icon(
+                    Icons.Default.Logout,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(10.dp))
+                Text("Sign Out", fontSize = 16.sp, color = Color.White)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SyncStatusCard(syncState: SyncState) {
+    var showSyncedConfirm by remember { mutableStateOf(false) }
+
+    LaunchedEffect(syncState) {
+        if (syncState == SyncState.SYNCED) {
+            showSyncedConfirm = true
+            delay(4_000)
+            showSyncedConfirm = false
+        }
+    }
+
+    val bgColor: Color
+    val icon: ImageVector
+    val title: String
+    val subtitle: String
+
+    when (syncState) {
+        SyncState.SYNCING -> {
+            bgColor  = Color(0xFF1565C0)
+            icon     = Icons.Default.Sync
+            title    = "Syncing…"
+            subtitle = "Uploading your latest changes to the cloud."
+        }
+        SyncState.SYNCED -> {
+            bgColor  = Color(0xFF2E7D32)
+            icon     = Icons.Default.CloudDone
+            title    = "Up to date"
+            subtitle = "All changes are saved to the cloud."
+        }
+        SyncState.OFFLINE_CACHE -> {
+            bgColor  = Color(0xFFE65100)
+            icon     = Icons.Default.CloudOff
+            title    = "Offline"
+            subtitle = "Changes will sync automatically when you reconnect."
+        }
+        SyncState.OFFLINE_BACKUP -> {
+            bgColor  = Color(0xFFC62828)
+            icon     = Icons.Default.CloudOff
+            title    = "Offline — read-only"
+            subtitle = "Showing a local backup. Changes can't be saved right now."
+        }
+    }
+
+    val visible = syncState != SyncState.SYNCED || showSyncedConfirm
+
+    AnimatedVisibility(visible = visible, enter = fadeIn(), exit = fadeOut()) {
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(bgColor)
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(28.dp)
+                )
+                Column {
+                    Text(
+                        title,
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp
+                    )
+                    Text(
+                        subtitle,
+                        color = Color.White.copy(alpha = 0.85f),
+                        fontSize = 12.sp
+                    )
+                }
+            }
+        }
+    }
+
+    if (syncState == SyncState.SYNCED && !showSyncedConfirm) {
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFF2E7D32))
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    Icons.Default.CloudDone,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(28.dp)
+                )
+                Column {
+                    Text("Up to date", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                    Text("All changes are saved to the cloud.", color = Color.White.copy(0.85f), fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    title,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+            }
+            Icon(
+                Icons.Default.ChevronRight,
+                null,
+                tint = Color.Gray,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}


### PR DESCRIPTION
- Created SettingsScreen with sync status banner, export wardrobe and sign out
- Profile screen now shows photo, name, email, bio and edit button only
- Replaced edit pencil icon in profile TopAppBar with a settings gear
- Removed OfflineSyncBanner  from home screen
- Settings accessible via gear icon on the profile screen