### PR TITLE
Donation map feature

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-17T18:29:17.989752100Z">
+        <DropdownSelection timestamp="2026-04-17T20:55:00.099331200Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=N5LNU20829411845" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\amypc\.android\avd\SCO_Phone.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,10 @@ android {
 
         val removeBgKey = localProperties.getProperty("REMOVE_BG_API_KEY") ?: ""
         buildConfigField("String", "REMOVE_BG_API_KEY", "\"$removeBgKey\"")
+
+        val mapsKey = project.findProperty("MAPS_API_KEY")?.toString() ?: ""
+        buildConfigField("String", "MAPS_API_KEY", "\"$mapsKey\"")
+        manifestPlaceholders["MAPS_API_KEY"] = mapsKey
     }
 
     buildTypes {
@@ -167,4 +171,11 @@ dependencies {
     implementation(libs.googleid)
 
     implementation(libs.androidx.datastore.preferences)
+
+    implementation(libs.maps.compose)
+    implementation(libs.play.services.maps)
+    implementation(libs.places)
+    implementation(libs.work.runtime.ktx)
+    implementation(libs.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
         val removeBgKey = localProperties.getProperty("REMOVE_BG_API_KEY") ?: ""
         buildConfigField("String", "REMOVE_BG_API_KEY", "\"$removeBgKey\"")
 
-        val mapsKey = project.findProperty("MAPS_API_KEY")?.toString() ?: ""
+        val mapsKey = localProperties.getProperty("MAPS_API_KEY") ?: ""
         buildConfigField("String", "MAPS_API_KEY", "\"$mapsKey\"")
         manifestPlaceholders["MAPS_API_KEY"] = mapsKey
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,16 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup" />
+        </provider>
+
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
             tools:node="merge">
             <meta-data
                 android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup" />
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".closet.main.MainApp"
@@ -15,6 +17,10 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />
 
 
         <provider

--- a/app/src/main/java/ie/setu/project/closet/main/MainApp.kt
+++ b/app/src/main/java/ie/setu/project/closet/main/MainApp.kt
@@ -1,15 +1,16 @@
 package ie.setu.project.closet.main
 
 import android.app.Application
+import com.google.android.libraries.places.api.Places
 import dagger.hilt.android.HiltAndroidApp
-import timber.log.Timber
+import ie.setu.project.BuildConfig
 
 @HiltAndroidApp
 class MainApp : Application() {
-
     override fun onCreate() {
         super.onCreate()
-        Timber.plant(Timber.DebugTree())
-        Timber.i("Closet Organiser started")
+        if (!Places.isInitialized()) {
+            Places.initializeWithNewPlacesApiEnabled(this, BuildConfig.MAPS_API_KEY)
+        }
     }
 }

--- a/app/src/main/java/ie/setu/project/closet/main/MainApp.kt
+++ b/app/src/main/java/ie/setu/project/closet/main/MainApp.kt
@@ -1,6 +1,8 @@
 package ie.setu.project.closet.main
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import com.google.android.libraries.places.api.Places
 import dagger.hilt.android.HiltAndroidApp
 import ie.setu.project.BuildConfig
@@ -12,5 +14,18 @@ class MainApp : Application() {
         if (!Places.isInitialized()) {
             Places.initializeWithNewPlacesApiEnabled(this, BuildConfig.MAPS_API_KEY)
         }
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            "donation_reminders",
+            "Donation Reminders",
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = "Reminds you to confirm your scheduled clothing donations"
+        }
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/ie/setu/project/closet/main/MainApp.kt
+++ b/app/src/main/java/ie/setu/project/closet/main/MainApp.kt
@@ -3,12 +3,24 @@ package ie.setu.project.closet.main
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import com.google.android.libraries.places.api.Places
 import dagger.hilt.android.HiltAndroidApp
 import ie.setu.project.BuildConfig
+import javax.inject.Inject
 
 @HiltAndroidApp
-class MainApp : Application() {
+class MainApp : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
     override fun onCreate() {
         super.onCreate()
         if (!Places.isInitialized()) {

--- a/app/src/main/java/ie/setu/project/firebase/donation/DonationPlanRepository.kt
+++ b/app/src/main/java/ie/setu/project/firebase/donation/DonationPlanRepository.kt
@@ -1,0 +1,40 @@
+package ie.setu.project.firebase.donation
+
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FirebaseFirestore
+import ie.setu.project.models.donation.DonationPlan
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DonationPlanRepository @Inject constructor(
+    private val db: FirebaseFirestore
+) {
+    private fun col(uid: String) =
+        db.collection("users").document(uid).collection("donationPlans")
+
+    suspend fun save(uid: String, plan: DonationPlan): DonationPlan {
+        val ref = if (plan.id.isBlank()) col(uid).document() else col(uid).document(plan.id)
+        val withId = plan.copy(id = ref.id)
+        ref.set(withId).await()
+        return withId
+    }
+
+    suspend fun getAll(uid: String): List<DonationPlan> =
+        col(uid).get().await().toObjects(DonationPlan::class.java)
+
+    suspend fun getPending(uid: String): List<DonationPlan> =
+        col(uid).whereEqualTo("confirmed", false).get().await()
+            .toObjects(DonationPlan::class.java)
+
+    suspend fun confirm(uid: String, planId: String) {
+        col(uid).document(planId).update(
+            mapOf("confirmed" to true, "confirmedAt" to Timestamp.now())
+        ).await()
+    }
+
+    suspend fun delete(uid: String, planId: String) {
+        col(uid).document(planId).delete().await()
+    }
+}

--- a/app/src/main/java/ie/setu/project/models/donation/DonationPlan.kt
+++ b/app/src/main/java/ie/setu/project/models/donation/DonationPlan.kt
@@ -1,0 +1,17 @@
+package ie.setu.project.models.donation
+
+import com.google.firebase.Timestamp
+
+data class DonationPlan(
+    val id: String = "",
+    val clothingItemId: Long = 0L,
+    val clothingTitle: String = "",
+    val locationId: String = "",
+    val locationName: String = "",
+    val locationAddress: String = "",
+    val locationLat: Double = 0.0,
+    val locationLng: Double = 0.0,
+    val scheduledDate: Timestamp = Timestamp.now(),
+    val confirmed: Boolean = false,
+    val confirmedAt: Timestamp? = null
+)

--- a/app/src/main/java/ie/setu/project/views/donation/DonatePlanSheet.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonatePlanSheet.kt
@@ -1,6 +1,10 @@
 package ie.setu.project.views.donation
 
 import android.app.DatePickerDialog
+import android.content.Context
+import android.view.ViewGroup
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,16 +17,18 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
-import com.google.android.gms.maps.model.CameraPosition
-import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.tasks.CancellationTokenSource
 import com.google.maps.android.compose.*
 import ie.setu.project.models.clothing.ClosetOrganiserModel
 import java.text.SimpleDateFormat
@@ -40,24 +46,54 @@ fun DonatePlanSheet(
     val isSearching      by vm.isSearchingMap.collectAsStateWithLifecycle()
     var selectedLocation by remember { mutableStateOf<DonationLocation?>(null) }
     var scheduledDate    by remember { mutableStateOf<Date?>(null) }
-    var userLatLng       by remember { mutableStateOf(LatLng(53.3498, -6.2603)) }
+    var userLatLng       by remember { mutableStateOf<com.google.android.gms.maps.model.LatLng?>(null) }
+    var locationError    by remember { mutableStateOf(false) }
+    var mapExpanded      by remember { mutableStateOf(false) }
+    var fetchLocation    by remember { mutableStateOf(false) }
     val sdf              = remember { SimpleDateFormat("EEE dd MMM yyyy", Locale.getDefault()) }
 
-    LaunchedEffect(Unit) {
-        try {
-            LocationServices.getFusedLocationProviderClient(context)
-                .lastLocation.addOnSuccessListener { loc ->
-                    if (loc != null) userLatLng = LatLng(loc.latitude, loc.longitude)
-                    vm.searchNearbyDonationSpots(userLatLng)
-                }
-        } catch (_: SecurityException) { vm.searchNearbyDonationSpots(userLatLng) }
+    val hasLocationPermission = androidx.core.content.ContextCompat.checkSelfPermission(
+        context, android.Manifest.permission.ACCESS_FINE_LOCATION
+    ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) fetchLocation = true
+        else locationError = true
     }
 
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(userLatLng, 14f)
+    LaunchedEffect(Unit) {
+        if (hasLocationPermission) fetchLocation = true
+        else locationPermissionLauncher.launch(android.Manifest.permission.ACCESS_FINE_LOCATION)
     }
+
+    LaunchedEffect(fetchLocation) {
+        if (!fetchLocation) return@LaunchedEffect
+        try {
+            val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+            val cts = CancellationTokenSource()
+            fusedClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cts.token)
+                .addOnSuccessListener { loc ->
+                    if (loc != null) {
+                        userLatLng = com.google.android.gms.maps.model.LatLng(loc.latitude, loc.longitude)
+                        vm.searchNearbyDonationSpots(userLatLng!!)
+                    } else {
+                        locationError = true
+                    }
+                }
+                .addOnFailureListener { locationError = true }
+        } catch (_: SecurityException) {
+            locationError = true
+        }
+    }
+
+    val cameraPositionState = rememberCameraPositionState()
+
     LaunchedEffect(userLatLng) {
-        cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(userLatLng, 14f))
+        userLatLng?.let {
+            cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(it, 14f))
+        }
     }
 
     ModalBottomSheet(
@@ -65,36 +101,102 @@ fun DonatePlanSheet(
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding()
         ) {
-            Text("Plan Donation — ${item.title.ifBlank { "Item" }}",
+            Text(
+                "Plan Donation: ${item.title.ifBlank { "Item" }}",
                 fontWeight = FontWeight.Bold, fontSize = 18.sp,
-                modifier = Modifier.padding(bottom = 12.dp))
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
 
-            Text("Nearby Donation Spots", fontWeight = FontWeight.SemiBold, fontSize = 14.sp,
-                modifier = Modifier.padding(bottom = 6.dp))
+            Text(
+                "Nearby Donation Spots",
+                fontWeight = FontWeight.SemiBold, fontSize = 14.sp,
+                modifier = Modifier.padding(bottom = 6.dp)
+            )
 
-            Box(modifier = Modifier.fillMaxWidth().height(220.dp)) {
-                GoogleMap(
-                    modifier = Modifier.fillMaxSize(),
-                    cameraPositionState = cameraPositionState,
-                    properties = MapProperties(isMyLocationEnabled = true),
-                    uiSettings = MapUiSettings(zoomControlsEnabled = false)
+            if (locationError) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(220.dp),
+                    contentAlignment = Alignment.Center
                 ) {
-                    nearbyLocations.forEach { loc ->
-                        Marker(
-                            state = MarkerState(position = loc.latLng),
-                            title = loc.name,
-                            snippet = loc.address,
-                            icon = if (loc.visitCount > 0)
-                                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN)
-                            else
-                                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ROSE),
-                            onClick = { selectedLocation = loc; false }
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(Icons.Default.LocationOff, null, tint = Color.Gray,
+                            modifier = Modifier.size(40.dp))
+                        Spacer(Modifier.height(8.dp))
+                        Text("Could not get your location", color = Color.Gray, fontSize = 14.sp)
+                        Text("Please enable location and try again",
+                            color = Color.Gray, fontSize = 12.sp)
+                    }
+                }
+            } else {
+                val mapHeight = if (mapExpanded) 450.dp else 220.dp
+
+                Box(modifier = Modifier.fillMaxWidth().height(mapHeight)) {
+                    AndroidView(
+                        factory = { ctx ->
+                            ComposeView(ctx).apply {
+                                layoutParams = ViewGroup.LayoutParams(
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                    ViewGroup.LayoutParams.MATCH_PARENT
+                                )
+                                setOnTouchListener { v, event ->
+                                    v.parent?.requestDisallowInterceptTouchEvent(true)
+                                    if (event.action == android.view.MotionEvent.ACTION_UP) v.performClick()
+                                    false
+                                }
+                            }
+                        },
+                        update = { composeView ->
+                            composeView.setContent {
+                                GoogleMap(
+                                    modifier = Modifier.fillMaxSize(),
+                                    cameraPositionState = cameraPositionState,
+                                    properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
+                                    uiSettings = MapUiSettings(zoomControlsEnabled = true)
+                                ) {
+                                    nearbyLocations.forEach { loc ->
+                                        Marker(
+                                            state = MarkerState(position = loc.latLng),
+                                            title = loc.name,
+                                            snippet = loc.address,
+                                            icon = if (loc.visitCount > 0)
+                                                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN)
+                                            else
+                                                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ROSE),
+                                            onClick = { selectedLocation = loc; false }
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                        modifier = Modifier.fillMaxSize()
+                    )
+
+                    if (isSearching || userLatLng == null) {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    }
+
+                    IconButton(
+                        onClick = { mapExpanded = !mapExpanded },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(4.dp)
+                    ) {
+                        Icon(
+                            if (mapExpanded) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier
+                                .background(Color.Black.copy(alpha = 0.4f), RoundedCornerShape(4.dp))
+                                .padding(4.dp)
+                                .size(20.dp)
                         )
                     }
                 }
-                if (isSearching) CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
 
             Spacer(Modifier.height(10.dp))
@@ -107,17 +209,24 @@ fun DonatePlanSheet(
                     ListItem(
                         headlineContent = {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                if (loc.visitCount > 0) Icon(Icons.Default.Star, null,
-                                    tint = Color(0xFFF9A825), modifier = Modifier.size(16.dp))
-                                Spacer(Modifier.width(4.dp))
-                                Text(loc.name, fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal)
+                                if (loc.visitCount > 0) {
+                                    Icon(Icons.Default.Star, null,
+                                        tint = Color(0xFFF9A825),
+                                        modifier = Modifier.size(16.dp))
+                                    Spacer(Modifier.width(4.dp))
+                                }
+                                Text(loc.name,
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal)
                             }
                         },
                         supportingContent = {
-                            Text(buildString {
-                                append(loc.address)
-                                if (loc.visitCount > 0) append("  •  Visited ${loc.visitCount}×")
-                            }, fontSize = 12.sp, color = Color.Gray)
+                            Text(
+                                buildString {
+                                    append(loc.address)
+                                    if (loc.visitCount > 0) append("  •  Visited ${loc.visitCount}×")
+                                },
+                                fontSize = 12.sp, color = Color.Gray
+                            )
                         },
                         leadingContent = {
                             Icon(Icons.Default.Store, null,
@@ -126,7 +235,8 @@ fun DonatePlanSheet(
                         modifier = Modifier.clickable { selectedLocation = loc },
                         colors = ListItemDefaults.colors(
                             containerColor = if (isSelected)
-                                MaterialTheme.colorScheme.primaryContainer else Color.Transparent
+                                MaterialTheme.colorScheme.primaryContainer
+                            else Color.Transparent
                         )
                     )
                     HorizontalDivider()
@@ -137,13 +247,22 @@ fun DonatePlanSheet(
             Text("Schedule Date", fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
             Spacer(Modifier.height(6.dp))
 
-            OutlinedButton(onClick = {
-                val cal = Calendar.getInstance()
-                DatePickerDialog(context, { _, y, m, d ->
-                    scheduledDate = Calendar.getInstance().apply { set(y, m, d, 9, 0, 0) }.time
-                }, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH))
-                    .also { it.datePicker.minDate = System.currentTimeMillis() }.show()
-            }, modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(
+                onClick = {
+                    val cal = Calendar.getInstance()
+                    DatePickerDialog(
+                        context,
+                        { _, y, m, d ->
+                            scheduledDate = Calendar.getInstance()
+                                .apply { set(y, m, d, 9, 0, 0) }.time
+                        },
+                        cal.get(Calendar.YEAR),
+                        cal.get(Calendar.MONTH),
+                        cal.get(Calendar.DAY_OF_MONTH)
+                    ).also { it.datePicker.minDate = System.currentTimeMillis() }.show()
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
                 Icon(Icons.Default.CalendarToday, null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(8.dp))
                 Text(scheduledDate?.let { sdf.format(it) } ?: "Pick a date")

--- a/app/src/main/java/ie/setu/project/views/donation/DonatePlanSheet.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonatePlanSheet.kt
@@ -1,7 +1,6 @@
 package ie.setu.project.views.donation
 
 import android.app.DatePickerDialog
-import android.content.Context
 import android.view.ViewGroup
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.background

--- a/app/src/main/java/ie/setu/project/views/donation/DonatePlanSheet.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonatePlanSheet.kt
@@ -1,0 +1,166 @@
+package ie.setu.project.views.donation
+
+import android.app.DatePickerDialog
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.*
+import ie.setu.project.models.clothing.ClosetOrganiserModel
+import java.text.SimpleDateFormat
+import java.util.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DonatePlanSheet(
+    item: ClosetOrganiserModel,
+    vm: DonationViewModel,
+    onDismiss: () -> Unit
+) {
+    val context          = LocalContext.current
+    val nearbyLocations  by vm.nearbyLocations.collectAsStateWithLifecycle()
+    val isSearching      by vm.isSearchingMap.collectAsStateWithLifecycle()
+    var selectedLocation by remember { mutableStateOf<DonationLocation?>(null) }
+    var scheduledDate    by remember { mutableStateOf<Date?>(null) }
+    var userLatLng       by remember { mutableStateOf(LatLng(53.3498, -6.2603)) }
+    val sdf              = remember { SimpleDateFormat("EEE dd MMM yyyy", Locale.getDefault()) }
+
+    LaunchedEffect(Unit) {
+        try {
+            LocationServices.getFusedLocationProviderClient(context)
+                .lastLocation.addOnSuccessListener { loc ->
+                    if (loc != null) userLatLng = LatLng(loc.latitude, loc.longitude)
+                    vm.searchNearbyDonationSpots(userLatLng)
+                }
+        } catch (_: SecurityException) { vm.searchNearbyDonationSpots(userLatLng) }
+    }
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(userLatLng, 14f)
+    }
+    LaunchedEffect(userLatLng) {
+        cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(userLatLng, 14f))
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding()
+        ) {
+            Text("Plan Donation — ${item.title.ifBlank { "Item" }}",
+                fontWeight = FontWeight.Bold, fontSize = 18.sp,
+                modifier = Modifier.padding(bottom = 12.dp))
+
+            Text("Nearby Donation Spots", fontWeight = FontWeight.SemiBold, fontSize = 14.sp,
+                modifier = Modifier.padding(bottom = 6.dp))
+
+            Box(modifier = Modifier.fillMaxWidth().height(220.dp)) {
+                GoogleMap(
+                    modifier = Modifier.fillMaxSize(),
+                    cameraPositionState = cameraPositionState,
+                    properties = MapProperties(isMyLocationEnabled = true),
+                    uiSettings = MapUiSettings(zoomControlsEnabled = false)
+                ) {
+                    nearbyLocations.forEach { loc ->
+                        Marker(
+                            state = MarkerState(position = loc.latLng),
+                            title = loc.name,
+                            snippet = loc.address,
+                            icon = if (loc.visitCount > 0)
+                                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN)
+                            else
+                                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ROSE),
+                            onClick = { selectedLocation = loc; false }
+                        )
+                    }
+                }
+                if (isSearching) CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+
+            Spacer(Modifier.height(10.dp))
+            Text("Select a location:", fontSize = 13.sp, color = Color.Gray)
+            Spacer(Modifier.height(4.dp))
+
+            LazyColumn(modifier = Modifier.heightIn(max = 180.dp)) {
+                items(nearbyLocations) { loc ->
+                    val isSelected = selectedLocation?.placeId == loc.placeId
+                    ListItem(
+                        headlineContent = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                if (loc.visitCount > 0) Icon(Icons.Default.Star, null,
+                                    tint = Color(0xFFF9A825), modifier = Modifier.size(16.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text(loc.name, fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal)
+                            }
+                        },
+                        supportingContent = {
+                            Text(buildString {
+                                append(loc.address)
+                                if (loc.visitCount > 0) append("  •  Visited ${loc.visitCount}×")
+                            }, fontSize = 12.sp, color = Color.Gray)
+                        },
+                        leadingContent = {
+                            Icon(Icons.Default.Store, null,
+                                tint = if (isSelected) MaterialTheme.colorScheme.primary else Color.Gray)
+                        },
+                        modifier = Modifier.clickable { selectedLocation = loc },
+                        colors = ListItemDefaults.colors(
+                            containerColor = if (isSelected)
+                                MaterialTheme.colorScheme.primaryContainer else Color.Transparent
+                        )
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            Spacer(Modifier.height(14.dp))
+            Text("Schedule Date", fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+            Spacer(Modifier.height(6.dp))
+
+            OutlinedButton(onClick = {
+                val cal = Calendar.getInstance()
+                DatePickerDialog(context, { _, y, m, d ->
+                    scheduledDate = Calendar.getInstance().apply { set(y, m, d, 9, 0, 0) }.time
+                }, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH))
+                    .also { it.datePicker.minDate = System.currentTimeMillis() }.show()
+            }, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.CalendarToday, null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(scheduledDate?.let { sdf.format(it) } ?: "Pick a date")
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = { vm.scheduleDonation(item, selectedLocation!!, scheduledDate!!) },
+                enabled = selectedLocation != null && scheduledDate != null,
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(Icons.Default.EventAvailable, null)
+                Spacer(Modifier.width(8.dp))
+                Text("Schedule Donation", fontSize = 16.sp)
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}

--- a/app/src/main/java/ie/setu/project/views/donation/DonationReminderWorker.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationReminderWorker.kt
@@ -10,7 +10,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import ie.setu.project.R
+
 
 @HiltWorker
 class DonationReminderWorker @AssistedInject constructor(
@@ -35,7 +35,7 @@ class DonationReminderWorker @AssistedInject constructor(
         )
 
         val notification = NotificationCompat.Builder(context, "donation_reminders")
-            .setSmallIcon(R.drawable.ic_heart)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setContentTitle("Donation Day!")
             .setContentText("Don't forget to drop off $itemTitle at $locationName today")
             .setStyle(NotificationCompat.BigTextStyle()

--- a/app/src/main/java/ie/setu/project/views/donation/DonationReminderWorker.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationReminderWorker.kt
@@ -1,0 +1,53 @@
+package ie.setu.project.views.donation
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import ie.setu.project.R
+
+@HiltWorker
+class DonationReminderWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters
+) : CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val itemTitle  = inputData.getString("item_title")  ?: "your item"
+        val locationName = inputData.getString("location_name") ?: "the donation spot"
+
+        val intent = context.packageManager
+            .getLaunchIntentForPackage(context.packageName)
+            ?.apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                putExtra("open_donation_tab", true)
+            }
+
+        val pendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, "donation_reminders")
+            .setSmallIcon(R.drawable.ic_heart)
+            .setContentTitle("Donation Day!")
+            .setContentText("Don't forget to drop off $itemTitle at $locationName today")
+            .setStyle(NotificationCompat.BigTextStyle()
+                .bigText("Don't forget to drop off $itemTitle at $locationName today. Open the app to confirm your donation."))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.notify(itemTitle.hashCode(), notification)
+
+        return Result.success()
+    }
+}

--- a/app/src/main/java/ie/setu/project/views/donation/DonationScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationScreen.kt
@@ -1,35 +1,19 @@
 package ie.setu.project.views.donation
 
-import android.net.Uri
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
 import ie.setu.project.R
-import ie.setu.project.models.clothing.ClosetOrganiserModel
-import java.text.SimpleDateFormat
-import java.util.*
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,18 +24,25 @@ fun DonationScreen(
     val flaggedItems    by vm.flaggedItems.collectAsStateWithLifecycle()
     val thresholdMonths by vm.thresholdMonths.collectAsStateWithLifecycle()
     val remindersOn     by vm.remindersEnabled.collectAsStateWithLifecycle()
-    val donatedCount    by vm.donatedCount.collectAsStateWithLifecycle()
+    val donationStats   by vm.donationStats.collectAsStateWithLifecycle()
+    val pendingPlans    by vm.pendingPlans.collectAsStateWithLifecycle()
+    val selectedItem    by vm.selectedItem.collectAsStateWithLifecycle()
 
     var showSettings by remember { mutableStateOf(false) }
+    var activeTab    by remember { mutableStateOf(0) }
 
     LaunchedEffect(Unit) { vm.refreshFlaggedItems() }
+
+    if (selectedItem != null) {
+        DonatePlanSheet(item = selectedItem!!, vm = vm, onDismiss = { vm.clearSelectedItem() })
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+                        Icon(Icons.Default.ArrowBack, "Back", tint = Color.White)
                     }
                 },
                 title = {
@@ -60,70 +51,61 @@ fun DonationScreen(
                         horizontalArrangement = Arrangement.Center,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Icon(painter = painterResource(id = R.drawable.ic_heart), contentDescription = null, tint = Color.White, modifier = Modifier.size(24.dp))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text("Donation Tracker", fontSize = 30.sp, fontFamily = androidx.compose.ui.text.font.FontFamily.Cursive, color = Color.White)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Icon(painter = painterResource(id = R.drawable.ic_heart), contentDescription = null, tint = Color.White, modifier = Modifier.size(24.dp))
+                        Icon(painterResource(R.drawable.ic_heart), null, tint = Color.White,
+                            modifier = Modifier.size(22.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text("Donation Tracker", fontSize = 28.sp,
+                            fontFamily = androidx.compose.ui.text.font.FontFamily.Cursive,
+                            color = Color.White)
+                        Spacer(Modifier.width(8.dp))
+                        Icon(painterResource(R.drawable.ic_heart), null, tint = Color.White,
+                            modifier = Modifier.size(22.dp))
                     }
                 },
                 actions = {
                     IconButton(onClick = { showSettings = !showSettings }) {
-                        Icon(Icons.Default.Settings, contentDescription = "Settings", tint = Color.White)
+                        Icon(Icons.Default.Settings, "Settings", tint = Color.White)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary)
             )
         }
     ) { padding ->
-
         Column(modifier = Modifier.padding(padding).fillMaxSize()) {
 
             if (showSettings) {
                 DonationSettingsPanel(
-                    thresholdMonths  = thresholdMonths,
-                    remindersEnabled = remindersOn,
+                    thresholdMonths   = thresholdMonths,
+                    remindersEnabled  = remindersOn,
                     onThresholdChange = { vm.setThresholdMonths(it) },
                     onRemindersChange = { vm.setRemindersEnabled(it) }
                 )
             }
 
-
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.primaryContainer)
-                    .padding(horizontal = 20.dp, vertical = 12.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                SummaryColumn("${flaggedItems.size}", "Flagged",   MaterialTheme.colorScheme.primary)
-                SummaryColumn("$donatedCount",        "Donated",   Color(0xFF2E7D32))
-                SummaryColumn("${thresholdMonths}mo", "Threshold", MaterialTheme.colorScheme.tertiary)
+                SummaryColumn("${flaggedItems.size}",         "Flagged",   MaterialTheme.colorScheme.primary)
+                SummaryColumn("${donationStats.totalDonated}","Donated",   Color(0xFF2E7D32))
+                SummaryColumn("${pendingPlans.size}",         "Planned",   Color(0xFFF57C00))
+                SummaryColumn("${thresholdMonths}mo",         "Threshold", MaterialTheme.colorScheme.tertiary)
             }
 
-            if (flaggedItems.isEmpty()) {
-                EmptyDonationState()
-            } else {
-                Text(
-                    "Items unworn for ${thresholdMonths}+ months",
-                    modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold
-                )
-                LazyColumn(
-                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    items(flaggedItems, key = { it.id }) { item ->
-                        DonationItemCard(
-                            item    = item,
-                            onDonate = { vm.markForDonation(item) },
-                            onKeep   = { vm.keepItem(item) }
-                        )
-                    }
-                }
+            TabRow(selectedTabIndex = activeTab) {
+                Tab(selected = activeTab == 0, onClick = { activeTab = 0 },
+                    text = { Text("To Donate") }, icon = { Icon(Icons.Default.Checkroom, null) })
+                Tab(selected = activeTab == 1, onClick = { activeTab = 1 },
+                    text = { Text("Planned") },   icon = { Icon(Icons.Default.Event, null) })
+                Tab(selected = activeTab == 2, onClick = { activeTab = 2 },
+                    text = { Text("Stats") },     icon = { Icon(Icons.Default.BarChart, null) })
+            }
+
+            when (activeTab) {
+                0 -> FlaggedTab(flaggedItems, thresholdMonths, onDonate = { vm.startDonationFlow(it) }, onKeep = { vm.keepItem(it) })
+                1 -> PlannedTab(pendingPlans, onConfirm = { vm.confirmDonation(it) }, onCancel = { vm.cancelPlan(it) })
+                2 -> StatsTab(donationStats)
             }
         }
     }
@@ -132,7 +114,7 @@ fun DonationScreen(
 @Composable
 private fun SummaryColumn(value: String, label: String, color: Color) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(value, fontSize = 28.sp, fontWeight = FontWeight.Bold, color = color)
+        Text(value, fontSize = 28.sp, fontWeight = androidx.compose.ui.text.font.FontWeight.Bold, color = color)
         Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
     }
 }
@@ -145,14 +127,13 @@ private fun DonationSettingsPanel(
     onRemindersChange: (Boolean) -> Unit
 ) {
     val options = listOf(3, 6, 9, 12)
-
     Card(
         modifier = Modifier.fillMaxWidth().padding(12.dp),
-        shape = RoundedCornerShape(14.dp),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text("Inactivity Threshold", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+            Text("Inactivity Threshold", fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold, fontSize = 15.sp)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 options.forEach { months ->
                     FilterChip(
@@ -166,14 +147,14 @@ private fun DonationSettingsPanel(
                     )
                 }
             }
-            Divider()
+            HorizontalDivider()
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Column {
-                    Text("Donation Reminders", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+                    Text("Donation Reminders", fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold, fontSize = 15.sp)
                     Text("Show badge on nav bar", fontSize = 12.sp, color = Color.Gray)
                 }
                 Switch(
@@ -185,113 +166,6 @@ private fun DonationSettingsPanel(
                     )
                 )
             }
-        }
-    }
-}
-
-@Composable
-fun DonationItemCard(
-    item: ClosetOrganiserModel,
-    onDonate: () -> Unit,
-    onKeep: () -> Unit
-) {
-    val daysSince = TimeUnit.MILLISECONDS.toDays(Date().time - item.lastWorn.time)
-    val sdf = remember { SimpleDateFormat("dd MMM yyyy", Locale.getDefault()) }
-
-    Card(
-        modifier  = Modifier.fillMaxWidth(),
-        shape     = RoundedCornerShape(14.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        colors    = CardDefaults.cardColors(containerColor = Color.Transparent),
-        border    = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
-    ) {
-        Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
-
-            Box(
-                modifier = Modifier
-                    .size(72.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(Color(0xFFF5F5F5))
-                    .border(2.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
-                contentAlignment = Alignment.Center
-            ) {
-                val imageModel: Any? = item.imageUrl.takeIf { it.isNotBlank() } ?: item.image
-                val hasImage = imageModel != null && imageModel != Uri.EMPTY && imageModel.toString().isNotBlank()
-                if (hasImage) {
-                    AsyncImage(
-                        model = imageModel,
-                        contentDescription = item.title,
-                        modifier = Modifier.fillMaxSize().padding(6.dp),
-                        contentScale = ContentScale.Fit
-                    )
-                } else {
-                    Icon(Icons.Default.Checkroom, contentDescription = null, tint = Color.LightGray, modifier = Modifier.size(32.dp))
-                }
-            }
-
-            Spacer(Modifier.width(12.dp))
-
-
-            Column(modifier = Modifier.weight(1f)) {
-                Text(item.title.ifBlank { "Unnamed item" }, fontWeight = FontWeight.Bold, fontSize = 15.sp, maxLines = 1)
-                if (item.category.isNotBlank()) Text(item.category, fontSize = 12.sp, color = Color.Gray)
-                Spacer(Modifier.height(4.dp))
-                Surface(
-                    shape = RoundedCornerShape(8.dp),
-                    color = when {
-                        daysSince >= 365 -> Color(0xFFFFCDD2)
-                        daysSince >= 180 -> Color(0xFFFFE0B2)
-                        else             -> Color(0xFFFFF9C4)
-                    }
-                ) {
-                    Text(
-                        "Unworn ${daysSince}d · last ${sdf.format(item.lastWorn)}",
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-                        fontSize = 11.sp,
-                        color = Color(0xFF4E342E),
-                        fontWeight = FontWeight.Medium
-                    )
-                }
-            }
-
-
-            Column(
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.padding(start = 8.dp)
-            ) {
-                FilledTonalButton(
-                    onClick = onDonate,
-                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
-                    colors = ButtonDefaults.filledTonalButtonColors(
-                        containerColor = Color(0xFFE8F5E9),
-                        contentColor   = Color(0xFF2E7D32)
-                    )
-                ) {
-                    Icon(Icons.Default.CardGiftcard, contentDescription = null, modifier = Modifier.size(14.dp))
-                    Spacer(Modifier.width(4.dp))
-                    Text("Donate", fontSize = 12.sp)
-                }
-                OutlinedButton(
-                    onClick = onKeep,
-                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp)
-                ) {
-                    Icon(Icons.Default.Favorite, contentDescription = null, modifier = Modifier.size(14.dp))
-                    Spacer(Modifier.width(4.dp))
-                    Text("Keep", fontSize = 12.sp)
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun EmptyDonationState() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = Color(0xFF2E7D32), modifier = Modifier.size(72.dp))
-            Text("Your wardrobe is clutter-free!", fontWeight = FontWeight.Bold, fontSize = 18.sp)
-            Text("No items inactive past your threshold.\nGreat job!", fontSize = 14.sp, color = Color.Gray, textAlign = TextAlign.Center)
         }
     }
 }

--- a/app/src/main/java/ie/setu/project/views/donation/DonationScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationScreen.kt
@@ -190,7 +190,7 @@ private fun DonationSettingsPanel(
 }
 
 @Composable
-private fun DonationItemCard(
+fun DonationItemCard(
     item: ClosetOrganiserModel,
     onDonate: () -> Unit,
     onKeep: () -> Unit
@@ -286,7 +286,7 @@ private fun DonationItemCard(
 }
 
 @Composable
-private fun EmptyDonationState() {
+fun EmptyDonationState() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Icon(Icons.Default.CheckCircle, contentDescription = null, tint = Color(0xFF2E7D32), modifier = Modifier.size(72.dp))

--- a/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
@@ -1,144 +1,264 @@
 package ie.setu.project.views.donation
 
 import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.android.gms.maps.model.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import ie.setu.project.BuildConfig
 import ie.setu.project.firebase.clothing.ClothingFirestoreRepository
+import ie.setu.project.firebase.donation.DonationPlanRepository
 import ie.setu.project.firebase.services.AuthService
 import ie.setu.project.models.clothing.ClosetOrganiserModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import ie.setu.project.models.donation.DonationPlan
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import com.google.firebase.Timestamp
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-val Context.donationDataStore: DataStore<Preferences> by preferencesDataStore(name = "donation_settings")
-
+val Context.donationDataStore by preferencesDataStore(name = "donation_settings")
 val PREF_THRESHOLD_MONTHS  = intPreferencesKey("inactivity_threshold_months")
 val PREF_REMINDERS_ENABLED = booleanPreferencesKey("donation_reminders_enabled")
 val PREF_DONATED_IDS       = stringSetPreferencesKey("donated_item_ids")
 val PREF_KEPT_IDS          = stringSetPreferencesKey("kept_item_ids")
+val PREF_LOCATION_VISITS   = stringPreferencesKey("location_visit_counts")
+
+data class DonationLocation(
+    val placeId: String,
+    val name: String,
+    val address: String,
+    val latLng: LatLng,
+    val type: LocationType,
+    val visitCount: Int = 0
+)
+
+enum class LocationType { CHARITY_SHOP, CLOTHING_BIN, OTHER }
+
+data class DonationStats(
+    val totalDonated: Int,
+    val favouriteLocation: String?,
+    val locationBreakdown: Map<String, Int>
+)
 
 @HiltViewModel
 class DonationViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val authService: AuthService,
-    private val clothingRepo: ClothingFirestoreRepository
+    private val clothingRepo: ClothingFirestoreRepository,
+    private val donationPlanRepo: DonationPlanRepository
 ) : ViewModel() {
 
-    private val _flaggedItems    = MutableStateFlow<List<ClosetOrganiserModel>>(emptyList())
+    private val _flaggedItems     = MutableStateFlow<List<ClosetOrganiserModel>>(emptyList())
     val flaggedItems: StateFlow<List<ClosetOrganiserModel>> = _flaggedItems.asStateFlow()
 
-    private val _thresholdMonths = MutableStateFlow(6)
+    private val _thresholdMonths  = MutableStateFlow(6)
     val thresholdMonths: StateFlow<Int> = _thresholdMonths.asStateFlow()
 
     private val _remindersEnabled = MutableStateFlow(true)
     val remindersEnabled: StateFlow<Boolean> = _remindersEnabled.asStateFlow()
 
-    private val _donatedCount = MutableStateFlow(0)
-    val donatedCount: StateFlow<Int> = _donatedCount.asStateFlow()
+    private val _donationStats    = MutableStateFlow(DonationStats(0, null, emptyMap()))
+    val donationStats: StateFlow<DonationStats> = _donationStats.asStateFlow()
+
+    private val _nearbyLocations  = MutableStateFlow<List<DonationLocation>>(emptyList())
+    val nearbyLocations: StateFlow<List<DonationLocation>> = _nearbyLocations.asStateFlow()
+
+    private val _pendingPlans     = MutableStateFlow<List<DonationPlan>>(emptyList())
+    val pendingPlans: StateFlow<List<DonationPlan>> = _pendingPlans.asStateFlow()
+
+    private val _isSearchingMap   = MutableStateFlow(false)
+    val isSearchingMap: StateFlow<Boolean> = _isSearchingMap.asStateFlow()
+
+    private val _selectedItem     = MutableStateFlow<ClosetOrganiserModel?>(null)
+    val selectedItem: StateFlow<ClosetOrganiserModel?> = _selectedItem.asStateFlow()
 
     init { loadPreferences() }
 
-    private fun loadPreferences() {
-        viewModelScope.launch {
-            val prefs = context.donationDataStore.data.first()
-            _thresholdMonths.value  = prefs[PREF_THRESHOLD_MONTHS]  ?: 6
-            _remindersEnabled.value = prefs[PREF_REMINDERS_ENABLED] ?: true
-            refreshFlaggedItems()
-        }
-    }
-
-    fun setThresholdMonths(months: Int) {
-        viewModelScope.launch {
-            context.donationDataStore.edit { it[PREF_THRESHOLD_MONTHS] = months }
-            _thresholdMonths.value = months
-            refreshFlaggedItems()
-        }
-    }
-
-    fun setRemindersEnabled(enabled: Boolean) {
-        viewModelScope.launch {
-            context.donationDataStore.edit { it[PREF_REMINDERS_ENABLED] = enabled }
-            _remindersEnabled.value = enabled
-        }
+    private fun loadPreferences() = viewModelScope.launch {
+        val prefs = context.donationDataStore.data.first()
+        _thresholdMonths.value  = prefs[PREF_THRESHOLD_MONTHS]  ?: 6
+        _remindersEnabled.value = prefs[PREF_REMINDERS_ENABLED] ?: true
+        refreshFlaggedItems()
+        refreshStats()
+        refreshPendingPlans()
     }
 
     fun refreshFlaggedItems() {
         val uid = authService.currentUserId
         if (uid.isBlank()) return
-
         viewModelScope.launch {
             val prefs         = context.donationDataStore.data.first()
-            val keptIds       = prefs[PREF_KEPT_IDS]?.mapNotNull { it.toLongOrNull() }?.toSet() ?: emptySet()
+            val keptIds       = prefs[PREF_KEPT_IDS]?.mapNotNull { it.toLongOrNull() }?.toSet()    ?: emptySet()
             val donatedIds    = prefs[PREF_DONATED_IDS]?.mapNotNull { it.toLongOrNull() }?.toSet() ?: emptySet()
             val thresholdDays = (_thresholdMonths.value * 30.44).toLong()
             val now           = Date()
-
-            _donatedCount.value = donatedIds.size
-
             try {
                 val allItems = clothingRepo.getAll(uid)
                 _flaggedItems.value = allItems.filter { item ->
                     val daysSince = TimeUnit.MILLISECONDS.toDays(now.time - item.lastWorn.time)
-                    daysSince >= thresholdDays &&
-                            item.id !in keptIds &&
-                            item.id !in donatedIds
+                    daysSince >= thresholdDays && item.id !in keptIds && item.id !in donatedIds
                 }
             } catch (_: Exception) { }
         }
     }
 
-    fun markForDonation(item: ClosetOrganiserModel) {
+    fun setThresholdMonths(months: Int) = viewModelScope.launch {
+        context.donationDataStore.edit { it[PREF_THRESHOLD_MONTHS] = months }
+        _thresholdMonths.value = months
+        refreshFlaggedItems()
+    }
+
+    fun setRemindersEnabled(enabled: Boolean) = viewModelScope.launch {
+        context.donationDataStore.edit { it[PREF_REMINDERS_ENABLED] = enabled }
+        _remindersEnabled.value = enabled
+    }
+
+    fun keepItem(item: ClosetOrganiserModel) = viewModelScope.launch {
+        context.donationDataStore.edit { prefs ->
+            prefs[PREF_KEPT_IDS] = (prefs[PREF_KEPT_IDS] ?: emptySet()) + item.id.toString()
+        }
+        _flaggedItems.value = _flaggedItems.value.filter { it.id != item.id }
+    }
+
+    fun startDonationFlow(item: ClosetOrganiserModel) { _selectedItem.value = item }
+    fun clearSelectedItem() { _selectedItem.value = null }
+
+    fun scheduleDonation(item: ClosetOrganiserModel, location: DonationLocation, scheduledDate: Date) {
         val uid = authService.currentUserId
         if (uid.isBlank()) return
+        viewModelScope.launch {
+            val plan = DonationPlan(
+                clothingItemId  = item.id,
+                clothingTitle   = item.title,
+                locationId      = location.placeId,
+                locationName    = location.name,
+                locationAddress = location.address,
+                locationLat     = location.latLng.latitude,
+                locationLng     = location.latLng.longitude,
+                scheduledDate   = Timestamp(scheduledDate)
+            )
+            donationPlanRepo.save(uid, plan)
+            _flaggedItems.value = _flaggedItems.value.filter { it.id != item.id }
+            refreshPendingPlans()
+            clearSelectedItem()
+        }
+    }
 
+    fun confirmDonation(plan: DonationPlan) {
+        val uid = authService.currentUserId
+        if (uid.isBlank()) return
+        viewModelScope.launch {
+            donationPlanRepo.confirm(uid, plan.id)
+            try {
+                val doc = clothingRepo.findDocByItemId(uid, plan.clothingItemId)
+                clothingRepo.deleteByDocId(uid, doc.id)
+            } catch (_: Exception) { }
+            context.donationDataStore.edit { prefs ->
+                prefs[PREF_DONATED_IDS] = (prefs[PREF_DONATED_IDS] ?: emptySet()) + plan.clothingItemId.toString()
+                val current = parseVisits(prefs[PREF_LOCATION_VISITS] ?: "")
+                current[plan.locationId] = (current[plan.locationId] ?: 0) + 1
+                prefs[PREF_LOCATION_VISITS] = encodeVisits(current, plan.locationName)
+            }
+            refreshStats()
+            refreshPendingPlans()
+        }
+    }
+
+    fun cancelPlan(plan: DonationPlan) = viewModelScope.launch {
+        val uid = authService.currentUserId
+        if (uid.isBlank()) return@launch
+        donationPlanRepo.delete(uid, plan.id)
+        refreshPendingPlans()
+        refreshFlaggedItems()
+    }
+
+    fun searchNearbyDonationSpots(userLocation: LatLng) {
+        _isSearchingMap.value = true
         viewModelScope.launch {
             try {
-                val doc = clothingRepo.findDocByItemId(uid, item.id)
-                clothingRepo.deleteByDocId(uid, doc.id)
+                val visitCounts = parseVisits(
+                    context.donationDataStore.data.first()[PREF_LOCATION_VISITS] ?: ""
+                )
+
+                val apiKey = BuildConfig.MAPS_API_KEY
+                val url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json" +
+                        "?location=${userLocation.latitude},${userLocation.longitude}" +
+                        "&radius=2000" +
+                        "&keyword=charity+clothes+donation+bin" +
+                        "&key=$apiKey"
+
+                val client = OkHttpClient()
+                val request = Request.Builder().url(url).build()
+                val responseBody = withContext(Dispatchers.IO) {
+                    client.newCall(request).execute().body?.string() ?: ""
+                }
+
+                val json    = JSONObject(responseBody)
+                val results = json.getJSONArray("results")
+
+                val locations = mutableListOf<DonationLocation>()
+                for (i in 0 until results.length()) {
+                    val place   = results.getJSONObject(i)
+                    val loc     = place.getJSONObject("geometry").getJSONObject("location")
+                    val placeId = place.getString("place_id")
+                    locations.add(
+                        DonationLocation(
+                            placeId    = placeId,
+                            name       = place.getString("name"),
+                            address    = place.optString("vicinity", ""),
+                            latLng     = LatLng(loc.getDouble("lat"), loc.getDouble("lng")),
+                            type       = LocationType.CHARITY_SHOP,
+                            visitCount = visitCounts[placeId] ?: 0
+                        )
+                    )
+                }
+                _nearbyLocations.value = locations.sortedByDescending { it.visitCount }
+
             } catch (e: Exception) {
-                timber.log.Timber.e(e, "Donation delete failed for id=${item.id}")
+                timber.log.Timber.e(e, "Places search failed")
+            } finally {
+                _isSearchingMap.value = false
             }
-
-            context.donationDataStore.edit { prefs ->
-                val current = prefs[PREF_DONATED_IDS] ?: emptySet()
-                prefs[PREF_DONATED_IDS] = current + item.id.toString()
-            }
-            _donatedCount.value++
-            _flaggedItems.value = _flaggedItems.value.filter { it.id != item.id }
         }
     }
 
-    fun keepItem(item: ClosetOrganiserModel) {
-        viewModelScope.launch {
-            context.donationDataStore.edit { prefs ->
-                val current = prefs[PREF_KEPT_IDS] ?: emptySet()
-                prefs[PREF_KEPT_IDS] = current + item.id.toString()
-            }
-            _flaggedItems.value = _flaggedItems.value.filter { it.id != item.id }
-        }
+    private fun refreshStats() = viewModelScope.launch {
+        val uid     = authService.currentUserId
+        val prefs   = context.donationDataStore.data.first()
+        val donated = prefs[PREF_DONATED_IDS] ?: emptySet()
+        val plans   = try { donationPlanRepo.getAll(uid).filter { it.confirmed } } catch (_: Exception) { emptyList() }
+        val breakdown = plans.groupingBy { it.locationName }.eachCount()
+        _donationStats.value = DonationStats(
+            totalDonated      = donated.size,
+            favouriteLocation = breakdown.maxByOrNull { it.value }?.key,
+            locationBreakdown = breakdown
+        )
     }
 
-    fun undoDecision(item: ClosetOrganiserModel) {
-        viewModelScope.launch {
-            context.donationDataStore.edit { prefs ->
-                prefs[PREF_KEPT_IDS]    = (prefs[PREF_KEPT_IDS]    ?: emptySet()) - item.id.toString()
-                prefs[PREF_DONATED_IDS] = (prefs[PREF_DONATED_IDS] ?: emptySet()) - item.id.toString()
-            }
-            refreshFlaggedItems()
-        }
+    private fun refreshPendingPlans() = viewModelScope.launch {
+        val uid = authService.currentUserId
+        if (uid.isBlank()) return@launch
+        try { _pendingPlans.value = donationPlanRepo.getPending(uid) } catch (_: Exception) { }
     }
+
+    private fun parseVisits(raw: String): MutableMap<String, Int> {
+        if (raw.isBlank()) return mutableMapOf()
+        return raw.split(",").mapNotNull {
+            val parts = it.split(":")
+            if (parts.size >= 3) parts[0] to (parts[2].toIntOrNull() ?: 0) else null
+        }.toMap().toMutableMap()
+    }
+
+    private fun encodeVisits(map: Map<String, Int>, locationNameHint: String = ""): String =
+        map.entries.joinToString(",") { "${it.key}:${locationNameHint}:${it.value}" }
 }

--- a/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
@@ -203,6 +203,8 @@ class DonationViewModel @Inject constructor(
                     client.newCall(request).execute().body?.string() ?: ""
                 }
 
+                android.util.Log.d("DonationVM", "Places response: $responseBody")
+
                 val json    = JSONObject(responseBody)
                 val results = json.getJSONArray("results")
 
@@ -225,7 +227,7 @@ class DonationViewModel @Inject constructor(
                 _nearbyLocations.value = locations.sortedByDescending { it.visitCount }
 
             } catch (e: Exception) {
-                timber.log.Timber.e(e, "Places search failed")
+                android.util.Log.e("DonationVM", "Places search failed: ${e.message}", e)
             } finally {
                 _isSearchingMap.value = false
             }

--- a/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.Timestamp
@@ -271,6 +272,7 @@ class DonationViewModel @Inject constructor(
             .setInitialDelay(delay, TimeUnit.MILLISECONDS)
             .setInputData(data)
             .addTag("donation_${plan.id}")
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         WorkManager.getInstance(context).enqueue(request)

--- a/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/DonationViewModel.kt
@@ -5,7 +5,11 @@ import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.google.android.gms.maps.model.LatLng
+import com.google.firebase.Timestamp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import ie.setu.project.BuildConfig
@@ -21,7 +25,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
-import com.google.firebase.Timestamp
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -147,7 +150,8 @@ class DonationViewModel @Inject constructor(
                 locationLng     = location.latLng.longitude,
                 scheduledDate   = Timestamp(scheduledDate)
             )
-            donationPlanRepo.save(uid, plan)
+            val savedPlan = donationPlanRepo.save(uid, plan)
+            scheduleNotification(savedPlan)
             _flaggedItems.value = _flaggedItems.value.filter { it.id != item.id }
             refreshPendingPlans()
             clearSelectedItem()
@@ -177,6 +181,7 @@ class DonationViewModel @Inject constructor(
     fun cancelPlan(plan: DonationPlan) = viewModelScope.launch {
         val uid = authService.currentUserId
         if (uid.isBlank()) return@launch
+        cancelNotification(plan)
         donationPlanRepo.delete(uid, plan.id)
         refreshPendingPlans()
         refreshFlaggedItems()
@@ -189,7 +194,6 @@ class DonationViewModel @Inject constructor(
                 val visitCounts = parseVisits(
                     context.donationDataStore.data.first()[PREF_LOCATION_VISITS] ?: ""
                 )
-
                 val apiKey = BuildConfig.MAPS_API_KEY
                 val url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json" +
                         "?location=${userLocation.latitude},${userLocation.longitude}" +
@@ -251,6 +255,29 @@ class DonationViewModel @Inject constructor(
         val uid = authService.currentUserId
         if (uid.isBlank()) return@launch
         try { _pendingPlans.value = donationPlanRepo.getPending(uid) } catch (_: Exception) { }
+    }
+
+    private fun scheduleNotification(plan: DonationPlan) {
+        val scheduledDate = plan.scheduledDate.toDate()
+        val delay = scheduledDate.time - System.currentTimeMillis()
+        if (delay <= 0) return
+
+        val data = Data.Builder()
+            .putString("item_title", plan.clothingTitle)
+            .putString("location_name", plan.locationName)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<DonationReminderWorker>()
+            .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+            .setInputData(data)
+            .addTag("donation_${plan.id}")
+            .build()
+
+        WorkManager.getInstance(context).enqueue(request)
+    }
+
+    private fun cancelNotification(plan: DonationPlan) {
+        WorkManager.getInstance(context).cancelAllWorkByTag("donation_${plan.id}")
     }
 
     private fun parseVisits(raw: String): MutableMap<String, Int> {

--- a/app/src/main/java/ie/setu/project/views/donation/FlaggedTab.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/FlaggedTab.kt
@@ -1,0 +1,36 @@
+package ie.setu.project.views.donation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import ie.setu.project.models.clothing.ClosetOrganiserModel
+
+@Composable
+fun FlaggedTab(
+    items: List<ClosetOrganiserModel>,
+    thresholdMonths: Int,
+    onDonate: (ClosetOrganiserModel) -> Unit,
+    onKeep: (ClosetOrganiserModel) -> Unit
+) {
+    if (items.isEmpty()) { EmptyDonationState(); return }
+    Text(
+        "Items unworn for ${thresholdMonths}+ months",
+        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.Bold
+    )
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(items, key = { it.id }) { item ->
+            DonationItemCard(item = item, onDonate = { onDonate(item) }, onKeep = { onKeep(item) })
+        }
+    }
+}

--- a/app/src/main/java/ie/setu/project/views/donation/FlaggedTab.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/FlaggedTab.kt
@@ -1,14 +1,32 @@
 package ie.setu.project.views.donation
 
+import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import ie.setu.project.models.clothing.ClosetOrganiserModel
+import java.text.SimpleDateFormat
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 @Composable
 fun FlaggedTab(
@@ -31,6 +49,114 @@ fun FlaggedTab(
     ) {
         items(items, key = { it.id }) { item ->
             DonationItemCard(item = item, onDonate = { onDonate(item) }, onKeep = { onKeep(item) })
+        }
+    }
+}
+
+@Composable
+private fun DonationItemCard(
+    item: ClosetOrganiserModel,
+    onDonate: () -> Unit,
+    onKeep: () -> Unit
+) {
+    val daysSince = TimeUnit.MILLISECONDS.toDays(Date().time - item.lastWorn.time)
+    val sdf = remember { SimpleDateFormat("dd MMM yyyy", Locale.getDefault()) }
+
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(14.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        colors    = CardDefaults.cardColors(containerColor = Color.Transparent),
+        border    = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
+    ) {
+        Row(modifier = Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color(0xFFF5F5F5))
+                    .border(2.dp, Color(0xFF007A90).copy(alpha = 0.3f), RoundedCornerShape(10.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                val imageModel: Any? = item.imageUrl.takeIf { it.isNotBlank() } ?: item.image
+                val hasImage = imageModel != null && imageModel != Uri.EMPTY && imageModel.toString().isNotBlank()
+                if (hasImage) {
+                    AsyncImage(
+                        model = imageModel,
+                        contentDescription = item.title,
+                        modifier = Modifier.fillMaxSize().padding(6.dp),
+                        contentScale = ContentScale.Fit
+                    )
+                } else {
+                    Icon(Icons.Default.Checkroom, contentDescription = null, tint = Color.LightGray, modifier = Modifier.size(32.dp))
+                }
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(item.title.ifBlank { "Unnamed item" }, fontWeight = FontWeight.Bold, fontSize = 15.sp, maxLines = 1)
+                if (item.category.isNotBlank()) Text(item.category, fontSize = 12.sp, color = Color.Gray)
+                Spacer(Modifier.height(4.dp))
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = when {
+                        daysSince >= 365 -> Color(0xFFFFCDD2)
+                        daysSince >= 180 -> Color(0xFFFFE0B2)
+                        else             -> Color(0xFFFFF9C4)
+                    }
+                ) {
+                    Text(
+                        "Unworn ${daysSince}d · last ${sdf.format(item.lastWorn)}",
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+                        fontSize = 11.sp,
+                        color = Color(0xFF4E342E),
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(start = 8.dp)
+            ) {
+                FilledTonalButton(
+                    onClick = onDonate,
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = Color(0xFFE8F5E9),
+                        contentColor   = Color(0xFF2E7D32)
+                    )
+                ) {
+                    Icon(Icons.Default.CardGiftcard, contentDescription = null, modifier = Modifier.size(14.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Donate", fontSize = 12.sp)
+                }
+                OutlinedButton(
+                    onClick = onKeep,
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp)
+                ) {
+                    Icon(Icons.Default.Favorite, contentDescription = null, modifier = Modifier.size(14.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Keep", fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDonationState() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = Color(0xFF2E7D32), modifier = Modifier.size(72.dp))
+            Text("Your wardrobe is clutter-free!", fontWeight = FontWeight.Bold, fontSize = 18.sp)
+            Text("No items inactive past your threshold.\nGreat job!", fontSize = 14.sp, color = Color.Gray, textAlign = TextAlign.Center)
         }
     }
 }

--- a/app/src/main/java/ie/setu/project/views/donation/PlannedTab.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/PlannedTab.kt
@@ -1,0 +1,109 @@
+package ie.setu.project.views.donation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ie.setu.project.models.donation.DonationPlan
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun PlannedTab(
+    plans: List<DonationPlan>,
+    onConfirm: (DonationPlan) -> Unit,
+    onCancel: (DonationPlan) -> Unit
+) {
+    if (plans.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Icon(Icons.Default.EventNote, null, tint = Color.Gray, modifier = Modifier.size(64.dp))
+                Spacer(Modifier.height(8.dp))
+                Text("No planned donations yet", color = Color.Gray)
+                Text("Tap 'Donate' on a flagged item to schedule one",
+                    fontSize = 12.sp, color = Color.Gray)
+            }
+        }
+        return
+    }
+
+    val sdf   = SimpleDateFormat("EEE dd MMM yyyy", Locale.getDefault())
+    val today = Calendar.getInstance().apply {
+        set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0);      set(Calendar.MILLISECOND, 0)
+    }.time
+
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(plans, key = { it.id }) { plan ->
+            val isDueToday = !plan.scheduledDate.toDate().after(today)
+            Card(
+                shape  = RoundedCornerShape(14.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isDueToday) Color(0xFFE8F5E9)
+                    else MaterialTheme.colorScheme.surfaceVariant
+                ),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.Checkroom, null,
+                            tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text(plan.clothingTitle, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                        if (isDueToday) {
+                            Spacer(Modifier.width(8.dp))
+                            Surface(shape = RoundedCornerShape(6.dp), color = Color(0xFF4CAF50)) {
+                                Text("TODAY",
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                    fontSize = 10.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(6.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.LocationOn, null, tint = Color.Gray, modifier = Modifier.size(14.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(plan.locationName, fontSize = 13.sp, color = Color.Gray)
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.CalendarToday, null, tint = Color.Gray, modifier = Modifier.size(14.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(sdf.format(plan.scheduledDate.toDate()), fontSize = 13.sp, color = Color.Gray)
+                    }
+                    Spacer(Modifier.height(10.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (isDueToday) {
+                            Button(
+                                onClick = { onConfirm(plan) },
+                                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2E7D32)),
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Icon(Icons.Default.CheckCircle, null, modifier = Modifier.size(16.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text("Confirm Donated")
+                            }
+                        }
+                        OutlinedButton(onClick = { onCancel(plan) }, modifier = Modifier.weight(1f)) {
+                            Icon(Icons.Default.Close, null, modifier = Modifier.size(16.dp))
+                            Spacer(Modifier.width(4.dp))
+                            Text("Cancel Plan")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/ie/setu/project/views/donation/StatsTab.kt
+++ b/app/src/main/java/ie/setu/project/views/donation/StatsTab.kt
@@ -1,0 +1,82 @@
+package ie.setu.project.views.donation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun StatsTab(stats: DonationStats) {
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item {
+            Card(shape = RoundedCornerShape(14.dp), modifier = Modifier.fillMaxWidth()) {
+                Row(modifier = Modifier.padding(20.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Favorite, null, tint = Color(0xFF2E7D32), modifier = Modifier.size(40.dp))
+                    Spacer(Modifier.width(16.dp))
+                    Column {
+                        Text("${stats.totalDonated}", fontSize = 36.sp,
+                            fontWeight = FontWeight.Bold, color = Color(0xFF2E7D32))
+                        Text("Items donated in total", fontSize = 14.sp, color = Color.Gray)
+                    }
+                }
+            }
+        }
+
+        if (stats.favouriteLocation != null) {
+            item {
+                Card(
+                    shape = RoundedCornerShape(14.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.Star, null, tint = Color(0xFFF9A825), modifier = Modifier.size(28.dp))
+                        Spacer(Modifier.width(12.dp))
+                        Column {
+                            Text("Favourite Drop-off", fontSize = 12.sp, color = Color.Gray)
+                            Text(stats.favouriteLocation, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                        }
+                    }
+                }
+            }
+        }
+
+        if (stats.locationBreakdown.isNotEmpty()) {
+            item {
+                Text("Donations by Location", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+            }
+            val sorted = stats.locationBreakdown.entries.sortedByDescending { it.value }
+            val max    = sorted.first().value.toFloat()
+            items(sorted) { (name, count) ->
+                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                    Icon(Icons.Default.LocationOn, null, tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(name, fontWeight = FontWeight.Medium, fontSize = 14.sp)
+                        LinearProgressIndicator(
+                            progress = { count / max },
+                            modifier = Modifier.fillMaxWidth().height(6.dp).padding(top = 2.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Text("$count", fontWeight = FontWeight.Bold, fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.primary)
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,11 @@ googleid = "1.1.0"
 ui = "1.10.5"
 datastorePreferences = "1.1.1"
 foundation = "1.10.6"
+mapsCompose = "4.3.3"
+playServicesMaps = "18.2.0"
+places = "3.4.0"
+workRuntimeKtx = "2.9.0"
+hiltWork = "1.2.0"
 
 
 
@@ -147,6 +152,13 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
+
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
+places = { module = "com.google.android.libraries.places:places", version.ref = "places" }
+work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
+hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltWork" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltWork" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Expanded the Donation Tracker from a simple flag-and-delete flow into a 
full donation planning experience.

What was implemented: 
- Tapping Donate on a flagged item opens a map bottom sheet showing 
  nearby charity shops and clothing bins within 2km using Google Places API
- User picks a location from the map or list and schedules a donation date
- Item stays in the closet until the user confirms they donated on the day
- WorkManager fires a push notification at 9am on the scheduled date reminding 
  the user to confirm
- New Planned tab shows all scheduled donations with a TODAY badge on due date
- New Stats tab shows total donated count, favourite drop-off location and 
  a breakdown of donations by location
- Previously visited locations appear as green markers on the map with a star
  in the list