### PR TITLE
User location setting

### DIFF
--- a/app/src/main/java/ie/setu/project/di/StoreModule.kt
+++ b/app/src/main/java/ie/setu/project/di/StoreModule.kt
@@ -12,6 +12,7 @@ import ie.setu.project.models.ClosetSQLStore
 import ie.setu.project.models.OutfitJSONStore
 import ie.setu.project.models.clothing.ClothingStore
 import ie.setu.project.models.outfit.OutfitStore
+import ie.setu.project.preferences.LocationPreferencesRepository
 import javax.inject.Singleton
 
 @Module
@@ -40,4 +41,10 @@ object StoreModule {
     fun provideOutfitCalendarFirestoreRepository(
         firestore: FirebaseFirestore
     ): OutfitCalendarFirestoreRepository = OutfitCalendarFirestoreRepository(firestore)
+
+    @Provides
+    @Singleton
+    fun provideLocationPreferencesRepository(@ApplicationContext context: Context): LocationPreferencesRepository {
+        return LocationPreferencesRepository(context)
+    }
 }

--- a/app/src/main/java/ie/setu/project/preferences/LocationPreferencesRepository.kt
+++ b/app/src/main/java/ie/setu/project/preferences/LocationPreferencesRepository.kt
@@ -1,0 +1,47 @@
+package ie.setu.project.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.dataStore by preferencesDataStore("location_prefs")
+
+data class LocationPreference(
+    val cityName: String,
+    val lat: Double,
+    val lon: Double
+)
+
+@Singleton
+class LocationPreferencesRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    companion object {
+        val KEY_CITY = stringPreferencesKey("city_name")
+        val KEY_LAT  = doublePreferencesKey("latitude")
+        val KEY_LON  = doublePreferencesKey("longitude")
+    }
+
+    val locationFlow: Flow<LocationPreference> = context.dataStore.data.map { prefs ->
+        LocationPreference(
+            cityName = prefs[KEY_CITY] ?: "Dublin",
+            lat      = prefs[KEY_LAT]  ?: 53.3498,
+            lon      = prefs[KEY_LON]  ?: -6.2603
+        )
+    }
+
+    suspend fun saveLocation(city: String, lat: Double, lon: Double) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_CITY] = city
+            prefs[KEY_LAT]  = lat
+            prefs[KEY_LON]  = lon
+        }
+    }
+}

--- a/app/src/main/java/ie/setu/project/views/clothingList/ClothingListPresenter.kt
+++ b/app/src/main/java/ie/setu/project/views/clothingList/ClothingListPresenter.kt
@@ -11,10 +11,12 @@ import ie.setu.project.models.LocalBackupRepository
 import ie.setu.project.models.clothing.ClosetOrganiserModel
 import ie.setu.project.models.outfit.OutfitModel
 import ie.setu.project.models.weather.WeatherResponse
+import ie.setu.project.preferences.LocationPreferencesRepository
 import ie.setu.project.weather.WeatherService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -29,7 +31,8 @@ class ClothingListPresenter @Inject constructor(
     private val clothingRepo: ClothingFirestoreRepository,
     private val outfitRepo: OutfitFirestoreRepository,
     private val imageStorageRepo: ImageStorageRepository,
-    private val localBackup: LocalBackupRepository
+    private val localBackup: LocalBackupRepository,
+    private val locationPrefs: LocationPreferencesRepository
 ) : ViewModel() {
 
     private val weatherService = WeatherService()
@@ -52,10 +55,8 @@ class ClothingListPresenter @Inject constructor(
     private val _showSearchResults = MutableStateFlow(false)
     val showSearchResults: StateFlow<Boolean> = _showSearchResults.asStateFlow()
 
-
     private val _syncState = MutableStateFlow(SyncState.SYNCING)
     val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
-
 
     private val _exportJson = MutableStateFlow<String?>(null)
     val exportJson: StateFlow<String?> = _exportJson.asStateFlow()
@@ -67,7 +68,11 @@ class ClothingListPresenter @Inject constructor(
     val weatherError: StateFlow<String?> = _weatherError.asStateFlow()
 
     init {
-        fetchWeather()
+        viewModelScope.launch {
+            locationPrefs.locationFlow.collect {
+                fetchWeather()
+            }
+        }
         refreshFromFirestore()
     }
 
@@ -96,7 +101,6 @@ class ClothingListPresenter @Inject constructor(
                 val q = _searchQuery.value.trim()
                 if (q.isNotBlank()) performSearch(q)
 
-
                 localBackup.backupFromFirestore(cachedClothing)
 
                 _syncState.value = SyncState.SYNCED
@@ -116,7 +120,8 @@ class ClothingListPresenter @Inject constructor(
     fun fetchWeather() {
         viewModelScope.launch {
             try {
-                val weather = weatherService.getWeather(53.3498, -6.2603)
+                val loc = locationPrefs.locationFlow.first()
+                val weather = weatherService.getWeather(loc.lat, loc.lon)
                 _weatherData.value = weather
             } catch (e: Exception) {
                 Timber.e(e, "Weather fetch failed")
@@ -125,6 +130,7 @@ class ClothingListPresenter @Inject constructor(
             }
         }
     }
+
     fun updateSearchQuery(query: String) {
         _searchQuery.value = query
         val q = query.trim()

--- a/app/src/main/java/ie/setu/project/views/settings/SettingsScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package ie.setu.project.views.settings
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -85,14 +86,16 @@ fun SettingsScreen(
             Text(
                 "Location",
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
+                color = Color(0xFF007A90),
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(start = 4.dp, top = 4.dp)
             )
 
             Card(
                 shape = RoundedCornerShape(12.dp),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+                border = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp),
@@ -103,12 +106,14 @@ fun SettingsScreen(
                             Icon(
                                 Icons.Default.LocationOn,
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary
+                                tint = Color(0xFF007A90)
                             )
                             Spacer(Modifier.width(8.dp))
                             Text(
-                                "Current: ${it.cityName}",
-                                style = MaterialTheme.typography.bodyMedium
+                                " ${it.cityName}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color(0xFF007A90)
                             )
                         }
                     }
@@ -120,14 +125,17 @@ fun SettingsScreen(
                             settingsViewModel.searchCity(it)
                         },
                         label = { Text("Search city…") },
-                        leadingIcon = { Icon(Icons.Default.Search, null) },
+                        leadingIcon = { Icon(Icons.Default.Search, null, tint = Color(0xFF007A90)) },
                         trailingIcon = {
-                            if (isSearching) {
-                                CircularProgressIndicator(modifier = Modifier.size(18.dp))
-                            }
+                            if (isSearching) CircularProgressIndicator(modifier = Modifier.size(18.dp))
                         },
                         modifier = Modifier.fillMaxWidth(),
-                        singleLine = true
+                        singleLine = true,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = Color(0xFF007A90),
+                            unfocusedBorderColor = Color(0xFF007A90).copy(alpha = 0.4f),
+                            focusedLabelColor = Color(0xFF007A90)
+                        )
                     )
 
                     searchResults.forEach { result ->
@@ -140,7 +148,8 @@ fun SettingsScreen(
                         ) {
                             Text(
                                 result.displayName,
-                                modifier = Modifier.fillMaxWidth()
+                                modifier = Modifier.fillMaxWidth(),
+                                color = Color(0xFF007A90)
                             )
                         }
                     }
@@ -150,14 +159,16 @@ fun SettingsScreen(
             Text(
                 "Data & Backup",
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
+                color = Color(0xFF007A90),
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(start = 4.dp, top = 4.dp)
             )
 
             Card(
                 shape = RoundedCornerShape(12.dp),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+                border = BorderStroke(1.5.dp, Color(0xFF007A90).copy(alpha = 0.4f))
             ) {
                 SettingsRow(
                     icon = Icons.Default.CloudUpload,
@@ -170,7 +181,7 @@ fun SettingsScreen(
             Text(
                 "Account",
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
+                color = Color(0xFF007A90),
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(start = 4.dp, top = 4.dp)
             )
@@ -314,12 +325,12 @@ private fun SettingsRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
+            Icon(icon, null, tint = Color(0xFF007A90))
             Column(modifier = Modifier.weight(1f)) {
                 Text(title, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
                 Text(subtitle, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
             }
-            Icon(Icons.Default.ChevronRight, null, tint = Color.Gray, modifier = Modifier.size(18.dp))
+            Icon(Icons.Default.ChevronRight, null, tint = Color(0xFF007A90), modifier = Modifier.size(18.dp))
         }
     }
 }

--- a/app/src/main/java/ie/setu/project/views/settings/SettingsScreen.kt
+++ b/app/src/main/java/ie/setu/project/views/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import ie.setu.project.R
 import ie.setu.project.views.clothingList.SyncState
 import kotlinx.coroutines.delay
@@ -31,8 +32,14 @@ fun SettingsScreen(
     syncState: SyncState,
     onExportWardrobe: () -> Unit,
     onSignOut: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
+    val currentLocation by settingsViewModel.currentLocation.collectAsState()
+    val searchResults by settingsViewModel.searchResults.collectAsState()
+    val isSearching by settingsViewModel.isSearching.collectAsState()
+    var cityQuery by remember { mutableStateOf("") }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -73,9 +80,72 @@ fun SettingsScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-
-
             SyncStatusCard(syncState = syncState)
+
+            Text(
+                "Location",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 4.dp, top = 4.dp)
+            )
+
+            Card(
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    currentLocation?.let {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Default.LocationOn,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                "Current: ${it.cityName}",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
+                    OutlinedTextField(
+                        value = cityQuery,
+                        onValueChange = {
+                            cityQuery = it
+                            settingsViewModel.searchCity(it)
+                        },
+                        label = { Text("Search city…") },
+                        leadingIcon = { Icon(Icons.Default.Search, null) },
+                        trailingIcon = {
+                            if (isSearching) {
+                                CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true
+                    )
+
+                    searchResults.forEach { result ->
+                        TextButton(
+                            onClick = {
+                                settingsViewModel.selectCity(result)
+                                cityQuery = ""
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                result.displayName,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
+                }
+            }
 
             Text(
                 "Data & Backup",
@@ -84,6 +154,7 @@ fun SettingsScreen(
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(start = 4.dp, top = 4.dp)
             )
+
             Card(
                 shape = RoundedCornerShape(12.dp),
                 modifier = Modifier.fillMaxWidth()
@@ -106,7 +177,9 @@ fun SettingsScreen(
 
             Button(
                 onClick = onSignOut,
-                modifier = Modifier.fillMaxWidth().height(52.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
                 shape = RoundedCornerShape(12.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFD32F2F))
             ) {
@@ -189,17 +262,8 @@ private fun SyncStatusCard(syncState: SyncState) {
                     modifier = Modifier.size(28.dp)
                 )
                 Column {
-                    Text(
-                        title,
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 15.sp
-                    )
-                    Text(
-                        subtitle,
-                        color = Color.White.copy(alpha = 0.85f),
-                        fontSize = 12.sp
-                    )
+                    Text(title, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                    Text(subtitle, color = Color.White.copy(alpha = 0.85f), fontSize = 12.sp)
                 }
             }
         }
@@ -252,23 +316,10 @@ private fun SettingsRow(
         ) {
             Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    title,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.Gray
-                )
+                Text(title, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
             }
-            Icon(
-                Icons.Default.ChevronRight,
-                null,
-                tint = Color.Gray,
-                modifier = Modifier.size(18.dp)
-            )
+            Icon(Icons.Default.ChevronRight, null, tint = Color.Gray, modifier = Modifier.size(18.dp))
         }
     }
 }

--- a/app/src/main/java/ie/setu/project/views/settings/SettingsViewModel.kt
+++ b/app/src/main/java/ie/setu/project/views/settings/SettingsViewModel.kt
@@ -1,0 +1,93 @@
+package ie.setu.project.views.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import ie.setu.project.preferences.LocationPreference
+import ie.setu.project.preferences.LocationPreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+import javax.inject.Inject
+
+private interface GeocodingApi {
+    @GET("v1/search")
+    suspend fun search(
+        @Query("name") name: String,
+        @Query("count") count: Int = 5,
+        @Query("language") language: String = "en",
+        @Query("format") format: String = "json"
+    ): GeocodingResponse
+}
+
+data class GeocodingResponse(val results: List<GeoResult>? = null)
+
+data class GeoResult(
+    val name: String,
+    val country: String?,
+    val latitude: Double,
+    val longitude: Double
+) {
+    val displayName get() = if (country != null) "$name, $country" else name
+}
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val locationPrefs: LocationPreferencesRepository
+) : ViewModel() {
+
+    private val geocodingApi = Retrofit.Builder()
+        .baseUrl("https://geocoding-api.open-meteo.com/")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(GeocodingApi::class.java)
+
+    private val _currentLocation = MutableStateFlow<LocationPreference?>(null)
+    val currentLocation: StateFlow<LocationPreference?> = _currentLocation.asStateFlow()
+
+    private val _searchResults = MutableStateFlow<List<GeoResult>>(emptyList())
+    val searchResults: StateFlow<List<GeoResult>> = _searchResults.asStateFlow()
+
+    private val _isSearching = MutableStateFlow(false)
+    val isSearching: StateFlow<Boolean> = _isSearching.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            locationPrefs.locationFlow.collect { _currentLocation.value = it }
+        }
+    }
+
+    fun searchCity(query: String) {
+        if (query.isBlank()) {
+            _searchResults.value = emptyList()
+            return
+        }
+        viewModelScope.launch {
+            _isSearching.value = true
+            try {
+                val response = geocodingApi.search(query)
+                _searchResults.value = response.results ?: emptyList()
+            } catch (e: Exception) {
+                _searchResults.value = emptyList()
+            } finally {
+                _isSearching.value = false
+            }
+        }
+    }
+
+    fun selectCity(result: GeoResult) {
+        viewModelScope.launch {
+            locationPrefs.saveLocation(result.displayName, result.latitude, result.longitude)
+            _searchResults.value = emptyList()
+        }
+    }
+
+    fun clearSearch() {
+        _searchResults.value = emptyList()
+    }
+}


### PR DESCRIPTION
Replaces the hardcoded Dublin coordinates in ClothingListPresenter with a user-selected location. Users can now search for their city in Settings, tap a result, and the weather card on the home screen will update to reflect their actual location. The chosen city persists across app restarts via DataStore.

Closes #37 
